### PR TITLE
refector : string resource / ResourceProvider

### DIFF
--- a/app/src/main/java/com/dontsu/digimonadventure/di/ResourceProviderModule.kt
+++ b/app/src/main/java/com/dontsu/digimonadventure/di/ResourceProviderModule.kt
@@ -1,0 +1,22 @@
+package com.dontsu.digimonadventure.di
+
+import android.content.Context
+import com.dontsu.presentation.util.ResourcesProvider
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ResourceProviderModule {
+
+    @Singleton
+    @Provides
+    fun provideResourcesProvider(@ApplicationContext context: Context): ResourcesProvider {
+        return ResourcesProvider(context = context)
+    }
+
+}

--- a/presentation/src/main/java/com/dontsu/presentation/ui/detail/DetailActivity.kt
+++ b/presentation/src/main/java/com/dontsu/presentation/ui/detail/DetailActivity.kt
@@ -1,6 +1,5 @@
 package com.dontsu.presentation.ui.detail
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.widget.LinearLayout
@@ -113,29 +112,29 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>(Acti
         // do something...
     }
 
-    @SuppressLint("SetTextI18n")
     private fun setDigimon(digimon: Digimon) = with(binding) {
         digimonImageView.loadWithUrl(digimon.image?.first()?.href)
-        digimonIdTextView.text = "Digicode : ${digimon.id.toString().ifEmpty { DIGIMON_UNKNOWN }}"
-        collapsingToolbarLayout.title = digimon.name.toString().ifEmpty { DIGIMON_UNKNOWN }
-        digimonNameTextView.text = digimon.name.toString().ifEmpty { DIGIMON_UNKNOWN }
+        val unknownString = getString(R.string.unknown)
+        digimonIdTextView.text = getString(R.string.digicode, digimon.id.toString().ifEmpty { unknownString })
+        collapsingToolbarLayout.title = digimon.name.toString().ifEmpty { unknownString }
+        digimonNameTextView.text = digimon.name.toString().ifEmpty { unknownString }
         digimon.level?.let {
             levelValueTextView.text = if(it.isEmpty()) {
-                DIGIMON_UNKNOWN
+                unknownString
             } else {
                 it.first()?.level.toString()
             }
         }
         digimon.attribute?.let {
             attributeValueTextView.text = if (it.isEmpty()) {
-                DIGIMON_UNKNOWN
+                unknownString
             } else {
                 it.first()?.attribute.toString()
             }
         }
         digimon.type?.let {
             typeValueTextview.text = if (it.isEmpty()) {
-                DIGIMON_UNKNOWN
+                unknownString
             } else {
                 it.first()?.type.toString()
             }
@@ -168,7 +167,7 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>(Acti
                 description?.language == "en_us"
             }
             descriptionTextView.text = if (description == null) {
-                DIGIMON_NO_DESCRIPTION
+                getString(R.string.no_description)
             } else {
                 description.description
             }
@@ -178,8 +177,6 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>(Acti
     companion object {
 
         const val DIGIMON_ID_KEY = "DIGIMON_ID_KEY"
-        const val DIGIMON_UNKNOWN = "Unknown"
-        const val DIGIMON_NO_DESCRIPTION = "There is no description for this Digimon."
 
         fun newInstance(context: Context, id: Int?): Intent {
             return Intent(context, DetailActivity::class.java).apply {

--- a/presentation/src/main/java/com/dontsu/presentation/ui/detail/DetailViewModel.kt
+++ b/presentation/src/main/java/com/dontsu/presentation/ui/detail/DetailViewModel.kt
@@ -8,6 +8,8 @@ import com.dontsu.domain.model.Favorite
 import com.dontsu.domain.model.UiState
 import com.dontsu.domain.model.successOrNull
 import com.dontsu.domain.usecase.detail.*
+import com.dontsu.presentation.R
+import com.dontsu.presentation.util.ResourcesProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -21,10 +23,11 @@ class DetailViewModel @Inject constructor(
     private val addFavoriteUseCase: AddDigimonDetailFavoriteUseCaseImpl,
     getFavoriteUseCase: GetDigimonDetailFavoriteUseCaseImpl,
     private val deleteFavoriteUseCase: DeleteDigimonDetailFavoriteUseCaseImpl,
+    resourcesProvider: ResourcesProvider, // Using ResourceProvider for getString resource in ViewModel would be not a good way because of using context. but it would be okay if we don't use ResourceProvider to get theme.
     savedStateHandle: SavedStateHandle
 ): ViewModel() {
     private val digimonId: Int = savedStateHandle[DetailActivity.DIGIMON_ID_KEY]
-        ?: throw IllegalStateException("There is no value of the digimon id.")
+        ?: throw IllegalStateException(resourcesProvider.getString(R.string.no_value_of_id))
 
     private val _uiState: MutableStateFlow<UiState<Digimon>> = MutableStateFlow(UiState.Loading)
     val uiState = _uiState.asStateFlow()

--- a/presentation/src/main/java/com/dontsu/presentation/util/ResourceProvider.kt
+++ b/presentation/src/main/java/com/dontsu/presentation/util/ResourceProvider.kt
@@ -1,0 +1,20 @@
+package com.dontsu.presentation.util
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.os.Build
+import androidx.annotation.ColorRes
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+
+class ResourcesProvider(
+    private val context: Context
+) {
+    fun getString(@StringRes resId: Int): String = context.getString(resId)
+
+    fun getString(@StringRes resId: Int, vararg formArg: Any): String = context.getString(resId, *formArg)
+
+    fun getColor(@ColorRes resId: Int): Int = ContextCompat.getColor(context, resId)
+
+    fun getColorStateList(@ColorRes resId: Int): ColorStateList? =  ContextCompat.getColorStateList(context, resId)
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -16,4 +16,8 @@
     <string name="please_retry_again">Please retry again.</string>
     <string name="not_founded">not founded.</string>
     <string name="scroll_up">Scroll up</string>
+    <string name="unknown">Unknown</string>
+    <string name="digicode">Digicode : %s</string>
+    <string name="no_description">There is no description for this Digimon.</string>
+    <string name="no_value_of_id">There is no value of the digimon id.</string>
 </resources>


### PR DESCRIPTION
In DetailActivity, i changed raw strings to string resource. ResourceProvider is added to get string resource in ViewModel or somewhere. but this would be not a good way to use ResourceProvider in ViewModel because of the context. but it would be also okay if we don't use ResourceProvider to get an app theme.